### PR TITLE
✨ Better error message if `wetlab` is not added to the current instance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
               docs/notes/
           )
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --unsafe-fixes]
@@ -44,7 +44,7 @@ repos:
       - id: trailing-whitespace
       - id: check-case-conflict
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]

--- a/wetlab/__init__.py
+++ b/wetlab/__init__.py
@@ -70,18 +70,26 @@ def __getattr__(name):
 
 if _check_instance_setup():
     del __getattr__  # delete so that imports work out
-    from ._pert_curator import PertCurator
-    from .models import (
-        Biologic,
-        Biosample,
-        CombinationPerturbation,
-        Compound,
-        CompoundPerturbation,
-        Donor,
-        EnvironmentalPerturbation,
-        Experiment,
-        GeneticPerturbation,
-        PerturbationTarget,
-        Techsample,
-        Well,
-    )
+    try:
+      from ._pert_curator import PertCurator
+      from .models import (
+         Biologic,
+         Biosample,
+         CombinationPerturbation,
+         Compound,
+         CompoundPerturbation,
+         Donor,
+         EnvironmentalPerturbation,
+         Experiment,
+         GeneticPerturbation,
+         PerturbationTarget,
+         Techsample,
+         Well,
+      )
+    except RuntimeError as e:
+      if "isn't in an application in INSTALLED_APPS" in str(e):
+         raise RuntimeError(
+               "the 'wetlab' module is missing from this instance.\n"
+               "Please add it via the settings page on laminhub."
+         ) from e
+      raise

--- a/wetlab/__init__.py
+++ b/wetlab/__init__.py
@@ -71,25 +71,25 @@ def __getattr__(name):
 if _check_instance_setup():
     del __getattr__  # delete so that imports work out
     try:
-      from ._pert_curator import PertCurator
-      from .models import (
-         Biologic,
-         Biosample,
-         CombinationPerturbation,
-         Compound,
-         CompoundPerturbation,
-         Donor,
-         EnvironmentalPerturbation,
-         Experiment,
-         GeneticPerturbation,
-         PerturbationTarget,
-         Techsample,
-         Well,
-      )
+        from ._pert_curator import PertCurator
+        from .models import (
+            Biologic,
+            Biosample,
+            CombinationPerturbation,
+            Compound,
+            CompoundPerturbation,
+            Donor,
+            EnvironmentalPerturbation,
+            Experiment,
+            GeneticPerturbation,
+            PerturbationTarget,
+            Techsample,
+            Well,
+        )
     except RuntimeError as e:
-      if "isn't in an application in INSTALLED_APPS" in str(e):
-         raise RuntimeError(
-               "the 'wetlab' module is missing from this instance.\n"
-               "Please add it via the settings page on laminhub."
-         ) from e
-      raise
+        if "isn't in an application in INSTALLED_APPS" in str(e):
+            raise RuntimeError(
+                "the 'wetlab' module is missing from this instance.\n"
+                "Please add it via the settings page on laminhub."
+            ) from e
+        raise

--- a/wetlab/_pert_curator.py
+++ b/wetlab/_pert_curator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Literal
 
 import bionty as bt
 import lamindb as ln


### PR DESCRIPTION
Before:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lukas/code/lamindb/sub/wetlab/wetlab/__init__.py", line 73, in <module>
    from ._pert_curator import PertCurator
  File "/home/lukas/code/lamindb/sub/wetlab/wetlab/_pert_curator.py", line 24, in <module>
    from .models import (
  File "/home/lukas/code/lamindb/sub/wetlab/wetlab/models.py", line 59, in <module>
    class Compound(BioRecord, TracksRun, TracksUpdates):
  File "/home/lukas/code/lamindb/lamindb/models.py", line 575, in __new__
    new_class = super().__new__(cls, name, bases, attrs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lukas/miniforge3/envs/lamindb/lib/python3.12/site-packages/django/db/models/base.py", line 134, in __new__
    raise RuntimeError(
RuntimeError: Model class wetlab.models.Compound doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

After:

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
File ~/code/wetlab/wetlab/__init__.py:74
     73 try:
---> 74   from ._pert_curator import PertCurator
     75   from .models import (
     76      Biologic,
     77      Biosample,
   (...)
     87      Well,
     88   )

File ~/code/wetlab/wetlab/_pert_curator.py:24
     19             raise RuntimeError(
     20                 "cellxgene_lamin is not installed. Please install it to use PertCurator."
     21             )
---> 24 from .models import (
     25     Biologic,
     26     Compound,
     27     Donor,
     28     EnvironmentalPerturbation,
     29     GeneticPerturbation,
     30     PerturbationTarget,
     31 )
     33 if TYPE_CHECKING:

File ~/code/wetlab/wetlab/models.py:59
     47 # def _get_related_repr(instance, related_name: str) -> str:
     48 #     try:
     49 #         related_manager = getattr(instance, related_name)
   (...)
     55 #         return ""
     56 #     return ""
---> 59 class Compound(BioRecord, TracksRun, TracksUpdates):
     60     """Models a (chemical) compound such as a drug.
     61 
     62     Examples:
   (...)
     66         ... ).save()
     67     """

File ~/code/lamindb/lamindb/models.py:575, in Registry.__new__(cls, name, bases, attrs, **kwargs)
    574 def __new__(cls, name, bases, attrs, **kwargs):
--> 575     new_class = super().__new__(cls, name, bases, attrs, **kwargs)
    576     return new_class

File ~/miniforge3/envs/lamindb/lib/python3.12/site-packages/django/db/models/base.py:134, in ModelBase.__new__(cls, name, bases, attrs, **kwargs)
    133     if not abstract:
--> 134         raise RuntimeError(
    135             "Model class %s.%s doesn't declare an explicit "
    136             "app_label and isn't in an application in "
    137             "INSTALLED_APPS." % (module, name)
    138         )
    140 else:

RuntimeError: Model class wetlab.models.Compound doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.

The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
Cell In[1], line 3
      1 import lamindb as ln
      2 import bionty as bt
----> 3 import wetlab as wl
      5 ln.track()

File ~/code/wetlab/wetlab/__init__.py:91
     89 except RuntimeError as e:
     90   if "isn't in an application in INSTALLED_APPS" in str(e):
---> 91      raise RuntimeError(
     92            "Add wetlab to your instance using: import lamindb as ln; ln.settings.add_app('wetlab')"
     93      ) from e
     94   raise

RuntimeError: the 'wetlab' module is missing from this instance.
Please add it via the settings page on laminhub.
```

I had considered `from None` instead of `from e` but thought that maybe the additional context helps. Feedback is welcome.